### PR TITLE
Custom repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ Suggest adding them in the host application "scripts" section of package.json li
 
 ### `ui-core-install` Usage
 
-To install a specific sha:
+- To install with a specific sha:
 
-```bash
-npm run ui-core-install -- [SOME_UI_CORE_SHA]
-```
+  ```bash
+  npm run ui-core-install -- [SOME_UI_CORE_SHA]
+  ```
 
-To install a specific repo & sha (e.g. forked repo):
+  Note: This sha needs to be in `unisonweb/ui-core` repository.
 
-```bash
-npm run ui-core-install -- [SOME_UI_CORE_SHA] [SOME_UI_CORE_URL]
-# e.g. SOME_UI_CORE_URL=https://github.com/some-user/ui-core
-```
+- To install with a specific repo & sha (e.g. forked repo):
+
+  ```bash
+  npm run ui-core-install -- [SOME_UI_CORE_SHA] [SOME_UI_CORE_URL]
+  # e.g. SOME_UI_CORE_URL=https://github.com/some-user/ui-core
+  ```
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-ui-core-scripts
-===============
+# ui-core-scripts
 
 Various helper scripts to install and update
 [ui-core](https://github.com/unisonweb/ui-core) (the Unison design system and
@@ -19,6 +18,21 @@ Suggest adding them in the host application "scripts" section of package.json li
 }
 ```
 
-Community
---------
+### `ui-core-install` Usage
+
+To install a specific sha:
+
+```bash
+npm run ui-core-install -- [SOME_UI_CORE_SHA]
+```
+
+To install a specific repo & sha (e.g. forked repo):
+
+```bash
+npm run ui-core-install -- [SOME_UI_CORE_SHA] [SOME_UI_CORE_URL]
+# e.g. SOME_UI_CORE_URL=https://github.com/some-user/ui-core
+```
+
+## Community
+
 [Code of conduct](https://www.unisonweb.org/code-of-conduct/)

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+elm-stuff

--- a/example/elm-git.json
+++ b/example/elm-git.json
@@ -1,0 +1,8 @@
+{
+    "git-dependencies": {
+        "direct": {
+            "https://github.com/unisonweb/ui-core": "2f995e1248684ad17dd23298bdb8cd09904eca6e"
+        },
+        "indirect": {}
+    }
+}

--- a/example/elm.json
+++ b/example/elm.json
@@ -1,0 +1,47 @@
+{
+    "type": "application",
+    "source-directories": [
+        "elm-stuff/gitdeps/github.com/unisonweb/ui-core/src",
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "NoRedInk/elm-json-decode-pipeline": "1.0.1",
+            "avh4/elm-color": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/parser": "1.1.0",
+            "elm/regex": "1.0.0",
+            "elm/svg": "1.0.1",
+            "elm-community/html-extra": "3.4.0",
+            "elm-community/json-extra": "4.3.0",
+            "elm-community/list-extra": "8.7.0",
+            "elm-community/maybe-extra": "5.3.0",
+            "elm-community/string-extra": "4.0.1",
+            "krisajenkins/remotedata": "6.0.1",
+            "mgold/elm-nonempty-list": "4.2.0",
+            "noahzgordon/elm-color-extra": "1.0.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4",
+            "ryan-haskell/date-format": "1.0.0",
+            "stoeffel/set-extra": "1.2.3",
+            "wernerdegroot/listzipper": "4.0.0"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "fredcy/elm-parseint": "2.0.1"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "ui-core-scripts": "file:../"
+      }
+    },
+    "..": {
+      "name": "@unison-lang/ui-core-scripts",
+      "version": "1.1.9",
+      "dev": true,
+      "bin": {
+        "ui-core-check-css": "check-css-vars.mjs",
+        "ui-core-install": "ui-core-install.js",
+        "ui-core-update": "ui-core-update.js"
+      },
+      "devDependencies": {
+        "@octokit/core": "^4.2.0"
+      }
+    },
+    "node_modules/ui-core-scripts": {
+      "resolved": "..",
+      "link": true
+    }
+  }
+}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "test",
+  "name": "ui-core-scripts-example",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "test",
+      "name": "ui-core-scripts-example",
       "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
         "ui-core-scripts": "file:../"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ui-core-scripts-example",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "ui-core-install": "ui-core-install",
+    "ui-core-update": "ui-core-update"
+  },
+  "devDependencies": {
+    "ui-core-scripts": "file:../"
+  }
+}

--- a/ui-core-install.js
+++ b/ui-core-install.js
@@ -2,7 +2,6 @@
 
 const {
   elmGitInstall,
-  replaceElmGitSha,
   replaceElmGitRepoSha,
   getUICoreOriginFromElmGit,
 } = require("./ui-core");
@@ -10,9 +9,15 @@ const {
 const shaArg = process.argv.slice(2)[0];
 const repoArg = process.argv.slice(2)[1];
 
-if (repoArg && shaArg) {
-  console.log(`Replace elm-git repo & sha:`);
+// if sha & repo -> use both
+// if sha only -> default repo & sha
+// no args -> get current value
+
+if (shaArg && repoArg) {
+  // sha & repo specified -> use both
+  console.log("Both repo and sha are specified.");
   console.log({ repo: repoArg, sha: shaArg });
+
   Promise.resolve({ repo: repoArg, sha: shaArg })
     .then((args) => {
       return replaceElmGitRepoSha(args.repo, args.sha);
@@ -20,30 +25,32 @@ if (repoArg && shaArg) {
     .then(() =>
       elmGitInstall(repoArg.replace("https://", "./elm-stuff/gitdeps/"))
     );
-} else {
-  getUICoreOriginFromElmGit()
-    .then((uiCoreOrigin) => {
-      if (!uiCoreOrigin) {
-        console.error("No ui-core setting in elm-git.json!");
-        return;
-      }
-      if (shaArg) {
-        console.log(`Replace elm-git sha:`);
-        console.log({ sha: shaArg });
-        return replaceElmGitRepoSha(uiCoreOrigin.url, shaArg).then(
-          () => uiCoreOrigin
-        );
-      } else {
-        return Promise.resolve(uiCoreOrigin);
-      }
+} else if (shaArg) {
+  // only sha specified -> default repo & sha
+  const repo = "https://github.com/unisonweb/ui-core";
+
+  console.log("Only sha is specified. Using default repo with the sha.");
+  console.log({ repo: repo, sha: shaArg });
+
+  Promise.resolve(shaArg)
+    .then((sha) => {
+      return replaceElmGitRepoSha(repo, sha);
     })
-    .then((uiCoreOrigin) => {
-      if (!uiCoreOrigin) {
-        console.error("No ui-core setting in elm-git.json!");
-        return;
-      }
-      return elmGitInstall(
-        uiCoreOrigin.url.replace("https://", "./elm-stuff/gitdeps/")
-      );
-    });
+    .then(() =>
+      elmGitInstall(repo.replace("https://", "./elm-stuff/gitdeps/"))
+    );
+} else {
+  // no args -> use current value
+  getUICoreOriginFromElmGit().then((uiCoreOrigin) => {
+    if (!uiCoreOrigin) {
+      console.error("No ui-core setting in elm-git.json!");
+      return;
+    }
+    console.log("No args. Values in elm-git.json are used.");
+    console.log({ repo: uiCoreOrigin.url, sha: uiCoreOrigin.sha });
+
+    return elmGitInstall(
+      uiCoreOrigin.url.replace("https://", "./elm-stuff/gitdeps/")
+    );
+  });
 }

--- a/ui-core-install.js
+++ b/ui-core-install.js
@@ -1,9 +1,32 @@
 #!/usr/bin/env node
 
-const { elmGitInstall, replaceElmGitSha } = require("./ui-core");
+const {
+  elmGitInstall,
+  replaceElmGitSha,
+  replaceElmGitRepoSha,
+} = require("./ui-core");
 
 const shaArg = process.argv.slice(2)[0];
+const repoArg = process.argv.slice(2)[1];
 
-Promise.resolve(shaArg)
-  .then((sha) => (sha ? replaceElmGitSha(sha) : sha))
-  .then(() => elmGitInstall());
+if (repoArg && shaArg) {
+  console.log(`Replace elm-git repo & sha:`);
+  console.log({ repo: repoArg, sha: shaArg });
+  Promise.resolve({ repo: repoArg, sha: shaArg })
+    .then((args) => {
+      return replaceElmGitRepoSha(args.repo, args.sha);
+    })
+    .then(() => elmGitInstall());
+} else {
+  Promise.resolve(shaArg)
+    .then((sha) => {
+      if (sha) {
+        console.log(`Replace elm-git sha:`);
+        console.log({ sha: shaArg });
+        return replaceElmGitSha(sha);
+      } else {
+        return;
+      }
+    })
+    .then(() => elmGitInstall());
+}

--- a/ui-core-install.js
+++ b/ui-core-install.js
@@ -16,7 +16,9 @@ if (repoArg && shaArg) {
     .then((args) => {
       return replaceElmGitRepoSha(args.repo, args.sha);
     })
-    .then(() => elmGitInstall());
+    .then(() =>
+      elmGitInstall(repoArg.replace("https://", "./elm-stuff/gitdeps/"))
+    );
 } else {
   Promise.resolve(shaArg)
     .then((sha) => {

--- a/ui-core-update.js
+++ b/ui-core-update.js
@@ -3,9 +3,11 @@
 const {
   getLatestUICoreSha,
   elmGitInstall,
-  replaceElmGitSha,
+  replaceElmGitRepoSha,
 } = require("./ui-core");
 
 getLatestUICoreSha()
-  .then(replaceElmGitSha)
+  .then((sha) => {
+    return replaceElmGitRepoSha("https://github.com/unisonweb/ui-core", sha);
+  })
   .then(() => elmGitInstall());

--- a/ui-core.js
+++ b/ui-core.js
@@ -42,6 +42,8 @@ function replaceElmGitRepoSha(repo, sha) {
     .then(JSON.parse)
     .then((json) => {
       const direct = json["git-dependencies"].direct;
+
+      // TODO: remove '*/ui-core'
       delete direct["https://github.com/unisonweb/ui-core"]; // remove default ui-core to replace with custom one
 
       return {
@@ -57,6 +59,24 @@ function replaceElmGitRepoSha(repo, sha) {
     })
     .then(JSON.stringify)
     .then((data) => fs.writeFile("./elm-git.json", data));
+}
+
+function getUICoreOriginFromElmGit() {
+  return fs
+    .readFile("./elm-git.json")
+    .then(JSON.parse)
+    .then((json) => {
+      const directDict = json["git-dependencies"].direct;
+      for (const [key, value] of Object.entries(directDict)) {
+        if (key.includes("ui-core")) {
+          return {
+            url: key,
+            sha: value,
+          };
+        }
+      }
+      return undefined;
+    });
 }
 
 function getLatestUICoreSha() {
@@ -152,4 +172,5 @@ module.exports = {
   replaceElmGitRepoSha,
   elmGitInstall,
   getLatestUICoreSha,
+  getUICoreOriginFromElmGit,
 };

--- a/ui-core.js
+++ b/ui-core.js
@@ -144,7 +144,7 @@ module.exports = {
   install,
   elmGitInstall,
   replaceElmGitSha,
-  replaceElmGitURL,
+  replaceElmGitRepoSha,
   elmGitInstall,
   getLatestUICoreSha,
 };

--- a/ui-core.js
+++ b/ui-core.js
@@ -34,6 +34,29 @@ function replaceElmGitSha(sha) {
     .then((data) => fs.writeFile("./elm-git.json", data));
 }
 
+function replaceElmGitRepoSha(repo, sha) {
+  return fs
+    .readFile("./elm-git.json")
+    .then(JSON.parse)
+    .then((json) => {
+      const direct = json["git-dependencies"].direct;
+      delete direct["https://github.com/unisonweb/ui-core"]; // remove default ui-core to replace with custom one
+
+      return {
+        ...json,
+        ["git-dependencies"]: {
+          ...json["git-dependencies"],
+          direct: {
+            ...direct,
+            [repo]: sha,
+          },
+        },
+      };
+    })
+    .then(JSON.stringify)
+    .then((data) => fs.writeFile("./elm-git.json", data));
+}
+
 function getLatestUICoreSha() {
   const octokit = new Octokit();
 
@@ -121,6 +144,7 @@ module.exports = {
   install,
   elmGitInstall,
   replaceElmGitSha,
+  replaceElmGitURL,
   elmGitInstall,
   getLatestUICoreSha,
 };

--- a/ui-core.js
+++ b/ui-core.js
@@ -43,8 +43,12 @@ function replaceElmGitRepoSha(repo, sha) {
     .then((json) => {
       const direct = json["git-dependencies"].direct;
 
-      // TODO: remove '*/ui-core'
-      delete direct["https://github.com/unisonweb/ui-core"]; // remove default ui-core to replace with custom one
+      // remove ui-core dependencies to replace with custom one
+      Object.keys(direct).forEach((key) => {
+        if (key.endsWith("/ui-core")) {
+          delete direct[key];
+        }
+      });
 
       return {
         ...json,

--- a/ui-core.js
+++ b/ui-core.js
@@ -16,26 +16,6 @@ function npmInstall(
   return `npm install -C ${uiCorePath}`;
 }
 
-function replaceElmGitSha(sha) {
-  return fs
-    .readFile("./elm-git.json")
-    .then(JSON.parse)
-    .then((json) => {
-      return {
-        ...json,
-        ["git-dependencies"]: {
-          ...json["git-dependencies"],
-          direct: {
-            ...json["git-dependencies"].direct,
-            ["https://github.com/unisonweb/ui-core"]: sha,
-          },
-        },
-      };
-    })
-    .then(JSON.stringify)
-    .then((data) => fs.writeFile("./elm-git.json", data));
-}
-
 function replaceElmGitRepoSha(repo, sha) {
   return fs
     .readFile("./elm-git.json")
@@ -172,7 +152,6 @@ function elmGitInstall(
 module.exports = {
   install,
   elmGitInstall,
-  replaceElmGitSha,
   replaceElmGitRepoSha,
   elmGitInstall,
   getLatestUICoreSha,


### PR DESCRIPTION
Hello.
I've added a second argument to `ui-core-install` command, so that the URL of `ui-core` repository can be customized, e.g. when developing with a forked ui-core repository. This will solve the issue of https://github.com/unisonweb/ui-core-scripts/issues/1.

Also, I've added an example empty elm project, to test commands in this repo.

I hope this makes ui-core and unison-local-ui development easier.
